### PR TITLE
Fix contact information

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -146,8 +146,10 @@
         <address class="column is-5-desktop is-5-tablet is-10-mobile">
           <p>主催: 一般社団法人PyCon JP</p>
           <p id="contact-mail-address">PyCon JP 2020 in Tokyo is a production of the
-            <a href="http://www.pycon.jp/" target="blank">PyCon JP Committee</a>. Contact :
-            <a href="mailto:pyconjp@pycon.jp">pyconjp@pycon.jp</a>
+            <a href="http://www.pycon.jp/" target="blank">PyCon JP Committee</a>.
+          </p>
+          <p>For the latest information and contact information for PyCon JP 2020, please visit 
+            <a href="https://pyconjp.blogspot.com/search/label/pyconjp2020">our blog</a>.
           </p>
         </address>
         <div class="column is-7-desktop is-8-tablet is-10-mobile">


### PR DESCRIPTION
"Contact : pyconjp@pycon.jp "
のところ、
https://pyconjp.blogspot.com/search/label/pyconjp2020"
といった形でメアドを隠すPRです。
面倒な場合メアド消すでもいいです。
java script等関連がよくわかってないので、修正不完全かもしれません。
