### PR TITLE
fix logo jump url

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,7 +27,7 @@
     <div class="navbar is-primary add-nav-color">
       <div class="container">
         <div class="navbar-brand">
-          <a class="navbar-item" href="https://www.pycon.jp/2020/" target="_blank">
+          <a class="navbar-item" href="https://www.pycon.jp/" target="_blank">
             <img src="static/img/favicon.png" alt="Logo" />
           </a>
           <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navMenu">


### PR DESCRIPTION
ロゴクリックで404表示されることへの対策。
一案としてwww.pycon.jp TOPへ移動させる