### PR TITLE
fix contact information coc

### DIFF
--- a/docs/code-of-conduct.html
+++ b/docs/code-of-conduct.html
@@ -172,11 +172,11 @@
         </div>
         <address class="column is-5-desktop is-5-tablet is-10-mobile">
           <p>主催: 一般社団法人PyCon JP</p>
-          <p id="contact-mail-address">
-            PyCon JP 2020 in Tokyo is a production of the
-            <a href="http://www.pycon.jp/" target="blank">PyCon JP Committee</a>
-            . Contact :
-            <a href="mailto:pyconjp@pycon.jp">pyconjp@pycon.jp</a>
+          <p id="contact-mail-address">PyCon JP 2020 in Tokyo is a production of the
+            <a href="http://www.pycon.jp/" target="blank">PyCon JP Committee</a>.
+          </p>
+          <p>For the latest information and contact information for PyCon JP 2020, please visit 
+            <a href="https://pyconjp.blogspot.com/search/label/pyconjp2020">our blog</a>.
           </p>
         </address>
         <div class="column is-7-desktop is-8-tablet is-10-mobile">


### PR DESCRIPTION
行動規範のページに残っていた問い合わせ先をblogに変更