### PR TITLE
読み込んでいるcss,img,jsのパスを絶対パスに変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,23 +12,23 @@
     <meta property="og:title" content="PyCon JP 2020" />
     <meta property="og:description" content="プログラミング言語PythonのカンファレンスPyCon JP 2020の事前情報を配信します。" />
     <meta property="og:url" content="https://pycon.jp/2020/" />
-    <meta property="og:image" content="/static/img/ogimage.png" />
+    <meta property="og:image" content="https://pycon.jp/2020/static/img/ogimage.png" />
     <meta property="og:site_name" content="PyCon JP 2020 in Tokyo | Aug 28th &ndash; Aug 29th" />
     <meta property="og:locale" content="ja_JP" />
     <meta property="fb:app_id" content="appIDを入力" />
-    <link rel="stylesheet" href="./static/css/style.css" />
-    <link rel="stylesheet" href="./static/css/helper.css" />
-    <link rel="stylesheet" href="./static/css/animate.min.css" />
-    <link rel="shortcut icon" type="image/png" href="./static/img/favicon.png" />
+    <link rel="stylesheet" href="https://pycon.jp/2020/static/css/style.css" />
+    <link rel="stylesheet" href="https://pycon.jp/2020/static/css/helper.css" />
+    <link rel="stylesheet" href=".https://pycon.jp/2020/static/css/animate.min.css" />
+    <link rel="shortcut icon" type="image/png" href="https://pycon.jp/2020/static/img/favicon.png" />
     <script defer src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
-    <script src="./static/js/common.js"></script>
+    <script src=".https://pycon.jp/2020/static/js/common.js"></script>
   </head>
   <body>
     <div class="navbar is-primary add-nav-color">
       <div class="container">
         <div class="navbar-brand">
           <a class="navbar-item" href="https://pycon.jp/2020/">
-            <img src="static/img/favicon.png" alt="Logo" />
+            <img src="https://pycon.jp/2020/static/img/favicon.png" alt="Logo" />
           </a>
           <a role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navMenu">
             <span aria-hidden="true"></span>
@@ -97,7 +97,7 @@
           <div class="columns is-multiline is-mobile is-centered unique-hero-container">
             <div class="column is-5 is-hidden-touch unique--hero-map">
               <figure class="img">
-                <img src="./static/img/hero_maps@2x.png" alt="">
+                <img src="https://pycon.jp/2020/static/img/hero_maps@2x.png" alt="">
               </figure>
             </div>
             <div class="column is-6-desktop is-8-tablet is-12-mobile has-text-centered add--hero-img">
@@ -133,7 +133,7 @@
         <div class="column is-narrow is-narrow-mobile">
           <a href="http://www.pycon.jp/" target="_blank">
             <figure class="image">
-              <img src="./static/img/ogimage.png" alt="PyCon JP Committee" />
+              <img src="https://pycon.jp/2020/static/img/ogimage.png" alt="PyCon JP Committee" />
             </figure>
           </a>
         </div>
@@ -149,7 +149,7 @@
         <div class="column is-7-desktop is-8-tablet is-10-mobile">
           <div class="level">
             <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">
-              <img src="./static/img/88x31.229daa2.png" alt="クリエイティブ・コモンズ・ライセンス">
+              <img src="https://pycon.jp/2020/static/img/88x31.229daa2.png" alt="クリエイティブ・コモンズ・ライセンス">
             </a>
             <p class="content is-small">この Webサイト は
               <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。


### PR DESCRIPTION
 `https://pycon.jp/2020` でcssやjs、imgが上手く表示できていない現象を確認したので、読み込みパスを絶対パスに変更しました。ご確認をお願いします。