### PR TITLE
オンライン開催決定に伴う変更

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -115,18 +115,11 @@
               </h1>
               <p class="subtitle has-text-white is-size-6-desktop is-size-6-tablet is-size-7-mobile unique--hero-date">
                 Conference:
-                <span class="is-size-4-desktop is-size-4-tablet is-size-5-mobile">Aug.28</span>(Fri)-
-                <span class="is-size-4-desktop is-size-4-tablet is-size-5-mobile">29</span>(Sat)
+                <span class="is-size-4-desktop is-size-4-tablet is-size-5-mobile">Coming Soon</span>
                 <br>Sprint/Tutorial : Coming Soon
+                <br>
               </p>
-              <p class="subtitle has-text-success is-size-5-desktop is-size-3-tablet is-5-mobile unique--hero-place">@Ota
-                City Industrial Plaza PiO
-                <a class="linki has-text-link"
-                   href="https://www.google.com/maps?ll=35.55876,139.724151&z=16&t=m&hl=ja&gl=JP&mapclient=embed&cid=9945236205239848880">
-                  <span class="icon is-link">
-                    <i class="fas fa-map-marked-alt"></i>
-                  </span>
-                </a>
+              <p class="subtitle has-text-success is-size-5-desktop is-size-3-tablet is-5-mobile unique--hero-place">@Online
               </p>
               <a href="https://pyconjp.blogspot.com/2019/11/2020-staff-application-form.html"
                  class="button is-success is-medium unique--hero-button add--shadow" target="_blank">スタッフ募集中！</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,6 +96,9 @@
       </div>
     </div>
     <section class="hero is-medium unique--hero">
+      <div>
+        <a href="https://pyconjp.blogspot.com/2020/04/notice-of-online-conference.html"><span class="is-size-4-desktop is-size-4-tablet is-size-5-mobile">PyCon JP 2020 オンライン開催に関するお知らせ / PyCon JP 2020 will be held Online.</span></a>
+      </div>
       <div class="hero-body">
         <div class="container unique--hero-wrapper">
           <div class="columns is-multiline is-mobile is-centered unique-hero-container">


### PR DESCRIPTION
変更点
・オンライン開催に関するブログのリンクを上部に表示
・開催日程に変更が出る可能性を考慮し、日程を「Coming Soon」とした。
・会場を「Online」として、google mapのリンクを除去
<img width="1371" alt="スクリーンショット 2020-04-25 13 18 12" src="https://user-images.githubusercontent.com/22832130/80271166-8d5e4b80-86f8-11ea-81ad-cbdabd9c63cf.png">
<img width="193" alt="スクリーンショット 2020-04-25 13 16 49" src="https://user-images.githubusercontent.com/22832130/80271167-95b68680-86f8-11ea-97ff-3d568d0a1170.png">

以上です。

