### PR TITLE
オンライン開催のお知らせリンクを真ん中に表示

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -96,8 +96,10 @@
       </div>
     </div>
     <section class="hero is-medium unique--hero">
-      <div>
-        <a href="https://pyconjp.blogspot.com/2020/04/notice-of-online-conference.html"><span class="is-size-4-desktop is-size-4-tablet is-size-5-mobile">PyCon JP 2020 オンライン開催に関するお知らせ / PyCon JP 2020 will be held Online.</span></a>
+      <div class="container">
+        <div class="column">
+          <a href="https://pyconjp.blogspot.com/2020/04/notice-of-online-conference.html"><span class="is-size-4-desktop is-size-4-tablet is-size-5-mobile">PyCon JP 2020 オンライン開催に関するお知らせ / PyCon JP 2020 will be held Online.</span></a>
+        </div>
       </div>
       <div class="hero-body">
         <div class="container unique--hero-wrapper">


### PR DESCRIPTION
PC画面上で左によっているので直しました。

## PC表示

![pc_size](https://user-images.githubusercontent.com/6592904/80857692-fd3b7b80-8c8e-11ea-9e69-2fd55df3d107.png)

## タブレット表示

![tablet_size](https://user-images.githubusercontent.com/6592904/80857702-0d535b00-8c8f-11ea-92ea-e1873a41ad04.png)

## スマートフォン表示

![smartphone_size](https://user-images.githubusercontent.com/6592904/80857709-18a68680-8c8f-11ea-960d-d14bb01c6819.png)
