### PR TITLE
プロポーザル募集のボタンを仮実装

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -126,6 +126,11 @@
               </p>
               <a href="https://pyconjp.blogspot.com/2019/11/2020-staff-application-form.html"
                  class="button is-success is-medium unique--hero-button add--shadow" target="_blank">スタッフ募集中！</a>
+              <br>
+              <br>
+              <br>
+              <a href="https://pyconjp.blogspot.com/search/label/proposal"
+                 class="button is-success is-medium unique--hero-button add--shadow" target="_blank">Call for Proposals!</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
<img width="524" alt="スクリーンショット 2020-05-12 19 51 46" src="https://user-images.githubusercontent.com/22832130/81768656-8156f400-9516-11ea-98e3-6ccf83de6051.png">
<img width="192" alt="スクリーンショット 2020-05-12 19 53 35" src="https://user-images.githubusercontent.com/22832130/81768664-87e56b80-9516-11ea-827d-286e988c55ac.png">

プロポーザルのお知らせボタンを付けました。ただし、デザインと配置は仮のものになります。